### PR TITLE
Allow skip installation of service with environment variable

### DIFF
--- a/svc_windows.go
+++ b/svc_windows.go
@@ -8,17 +8,22 @@ package minwinsvc
 
 import (
 	"os"
+	"strconv"
 	"sync"
 
 	"golang.org/x/sys/windows/svc"
 )
 
 var (
-	onExit func()
-	guard  sync.Mutex
+	onExit  func()
+	guard   sync.Mutex
+	skip, _ = strconv.ParseBool(os.Getenv("SKIP_MINWINSVC"))
 )
 
 func init() {
+	if skip {
+		return
+	}
 	interactive, err := svc.IsAnInteractiveSession()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
`SKIP_MINWINSVC=1` will prevent the service from install.

This will be useful on Gitea because the executable calls itself in same cases, but should not run as a service.

@kardianos 