### PR TITLE
`IsWindowsService` instead of `IsService`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/kardianos/minwinsvc
 
 go 1.15
 
-require golang.org/x/sys v0.0.0-20221010170243-090e33056c14
+require golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 h1:OjiUf46hAmXblsZdnoSXsEUSKU8r1UEzcL5RVZ4gO9Y=
-golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
-golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43 h1:OK7RB6t2WQX54srQQYSXMW8dF5C6/8+oA/s5QBmmto4=
+golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/svc_windows.go
+++ b/svc_windows.go
@@ -20,7 +20,7 @@ var (
 )
 
 func init() {
-	isService, err := svc.IsService()
+	isService, err := svc.IsWindowsService()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Looking at the [godocs for `IsAnInteractiveSession `](https://pkg.go.dev/golang.org/x/sys/windows/svc#IsAnInteractiveSession), it looks like this should be `IsWindowsService` instead.

I noticed this after finding a build error when updating to minwinsvc 1.0.1.