### PR TITLE
Add GHA build tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   build:
+    name: minwinsvc (Go ${{ matrix.go }} / ${{ matrix.goos }})
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,34 @@
+name: Go
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ["1.15", "1.16", "1.17", "1.18", "1.19"]
+        goos: ["linux", "windows"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup (Go ${{ matrix.go }} / ${{ matrix.goos }})
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Build (Go ${{ matrix.go }} / ${{ matrix.goos }})
+        run: go build -v .
+        env:
+          GOOS: ${{ matrix.goos }}


### PR DESCRIPTION
This adds a dead simple GitHub Actions workflow to test whether minwinsvc builds on Linux and Windows on a range of Go versions. It should help to catch obvious issues.

Since your `go.mod` file claims support for Go 1.15 and above, the strategy matrix in the workflow includes all Go versions between 1.15 and 1.19.

There are some [failures currently](https://github.com/neilalexander/minwinsvc/actions/runs/3249014452/jobs/5330918936):
* `syscall_windows.go:141:29: undefined: unsafe.Slice` on Go 1.15 and Go 1.16 (may be worth just deprecating these versions and bumping your `go.mod` to `go 1.17`);
* `svc_windows.go:23:24: undefined: svc.IsService` which is fixed by #6.